### PR TITLE
updating url checker with 404 fix

### DIFF
--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -33,7 +33,15 @@ files <- list.files(path = root_dir, pattern = 'md$', full.names = TRUE)
 test_url <- function(url) {
   message(paste0("Testing: ", url))
   url_status <- try(httr::GET(url), silent = TRUE)
+  
+  # Fails if host can't be resolved
   status <- ifelse(suppressMessages(grepl("Could not resolve host", url_status)), "failed", "success")
+  
+  if (status == "success") {
+    # Fails if 404'ed
+    status <- ifelse(httr::status_code(httr::GET(url)) == 404, "failed", "success")
+  }
+  
   return(status)
 }
 


### PR DESCRIPTION
Adding the change here - I noticed there was one other small difference in the script from the main template (just checking that resource dir exists).

But perhaps @cansavvy you want to sync this instead.