### PR TITLE
Bump checkout version

### DIFF
--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Check out current repository
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Verify Dockerfiles changed?
         uses: tj-actions/verify-changed-files@v8.8

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
         # Use the yaml-env-action action.
       - name: Load environment from YAML
@@ -47,7 +47,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # get the full repo
           fetch-depth: 0


### PR DESCRIPTION
Bumps versions: `actions/checkout@v3` -> `actions/checkout@v4`

This addresses @cansavvy 's comment: https://github.com/jhudsl/ITCR_Tables/pull/32#pullrequestreview-1892804938