### PR TITLE
Add downloadable comprehensive preview

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -161,9 +161,10 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Quick preview for the latest commit: See [preview of website here](${{ steps.build-components.outputs.website_link }}) -- note not all html features will be properly displayed but it will give you a rough idea.
-            For a comprehensive preview [download the preview files by clicking this link](${{ steps.build-components.outputs.docs_link }}).
-
+            :eyes: [Quick preview of website here](${{ steps.build-components.outputs.website_link }})
+            :microscope: [Comprehensive download of the website here](${{ steps.build-components.outputs.docs_link }})
+            \* note not all html features will be properly displayed but it will give you a rough idea.
+            
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,8 +30,10 @@ jobs:
       # Make the branch fresh
       - name: Make the branch fresh
         run: |
-          git config --local user.email "itcrtrainingnetwork@gmail.com"
-          git config --local user.name "jhudsl-robot"
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
           branch_name='preview-${{ github.event.pull_request.number }}'
           echo branch doesnt exist
           git checkout -b $branch_name || echo branch exists
@@ -83,9 +85,9 @@ jobs:
       # Set up git checkout
       - name: Set up git checkout
         run: |
-          git config --system --add safe.directory $GITHUB_WORKSPACE
-          git config --local user.email "itcrtrainingnetwork@gmail.com"
-          git config --local user.name "jhudsl-robot"
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
           branch_name='preview-${{ github.event.pull_request.number }}'
           git fetch --all
@@ -112,7 +114,7 @@ jobs:
 
       - name: Website preview for download
         run: zip website-preview.zip docs/* -r
-        
+
       # Commit the rendered website files
       - name: Commit rendered website files to preview branch
         id: commit
@@ -131,7 +133,7 @@ jobs:
         with:
           name: website-preview
           path: website-preview.zip
-          
+
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         id: fc
@@ -159,8 +161,8 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Quick preview for the latest commit: See [preview of website here](${{ steps.build-components.outputs.website_link }})
-            Comprehensive [downloadable preview files](${{ steps.build-components.outputs.docs_link }})
+            Quick preview for the latest commit: See [preview of website here](${{ steps.build-components.outputs.website_link }}) -- note not all html features will be properly displayed but it will give you a rough idea.
+            For a comprehensive preview [download the preview files by clicking this link](${{ steps.build-components.outputs.docs_link }}).
 
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
@@ -176,5 +178,3 @@ jobs:
 
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
-
-

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           course_name=$(head -n 1 _website.yml | cut -d'"' -f 2| tr " " "-")
           website_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/index.html")
-          docs_link=$echo "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/website-preview.zip"
+          docs_link=$(echo "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/website-preview.zip")
           echo ::set-output name=website_link::$website_link
           echo ::set-output name=time::$(date +'%Y-%m-%d')
           echo ::set-output name=commit_id::$GITHUB_SHA

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -164,7 +164,7 @@ jobs:
             :eyes: Quick [preview of website here](${{ steps.build-components.outputs.website_link }}) \*
             :microscope: Comprehensive [download of the website here](${{ steps.build-components.outputs.docs_link }})
             
-            \* note not all html features will be properly displayed but it will give you a rough idea.
+            \* note not all html features will be properly displayed in the "quick preview" but it will give you a rough idea.
             
             _Updated at ${{ steps.build-components.outputs.time }} with changes from the latest commit ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           branch_name='preview-${{ github.event.pull_request.number }}'
           git diff origin/main -- '*.html' >/dev/null && changes=true || changes=false
-          echo ::set-output name=changes::$changes
+          echo "changes=$changes" >> $GITHUB_OUTPUT
           git add . --force
           git commit -m 'Render preview' || echo "No changes to commit"
           git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -142,7 +142,7 @@ jobs:
           course_name=$(head -n 1 _website.yml | cut -d'"' -f 2| tr " " "-")
           website_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/index.html")
           docs_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/website-preview.zip")
-          echo "docs_link=$docs_link" >> $GITHUB_OUTPUT
+          echo "zip_link=$docs_link" >> $GITHUB_OUTPUT
           echo "website_link=$website_link" >> $GITHUB_OUTPUT
           echo "time=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
           echo "commit_id=$GITHUB_SHA" >> $GITHUB_OUTPUT
@@ -156,10 +156,10 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             :eyes: Quick [preview of website here](${{ steps.build-components.outputs.website_link }}) \*
-            :microscope: Comprehensive [download of the website here](${{ steps.build-components.outputs.docs_link }})
-            
+            :microscope: Comprehensive [download of the website here](${{ steps.build-components.outputs.zip_link }})
+
             \* note not all html features will be properly displayed in the "quick preview" but it will give you a rough idea.
-            
+
             _Updated at ${{ steps.build-components.outputs.time }} with changes from the latest commit ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -123,6 +123,15 @@ jobs:
           git push --force || echo "No changes to commit"
         shell: bash
 
+      - name: Website preview for download
+        run: zip website-preview.zip docs/* -r
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v2
+        with:
+          name: website-preview
+          path: website-preview.zip
+          
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         id: fc

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -166,7 +166,7 @@ jobs:
             
             \* note not all html features will be properly displayed but it will give you a rough idea.
             
-            _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
+            _Updated at ${{ steps.build-components.outputs.time }} with changes from the latest commit ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 
       - name: No comment if no changes

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -161,8 +161,9 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            :eyes: [Quick preview of website here](${{ steps.build-components.outputs.website_link }})
-            :microscope: [Comprehensive download of the website here](${{ steps.build-components.outputs.docs_link }})
+            :eyes: Quick [preview of website here](${{ steps.build-components.outputs.website_link }}) \*
+            :microscope: Comprehensive [download of the website here](${{ steps.build-components.outputs.docs_link }})
+            
             \* note not all html features will be properly displayed but it will give you a rough idea.
             
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -128,12 +128,6 @@ jobs:
           git push --force || echo "No changes to commit"
         shell: bash
 
-      - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
-        with:
-          name: website-preview
-          path: website-preview.zip
-
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         id: fc

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -110,6 +110,9 @@ jobs:
           echo site status ${{steps.site.outcome}}
           exit 1
 
+      - name: Website preview for download
+        run: zip website-preview.zip docs/* -r
+        
       # Commit the rendered website files
       - name: Commit rendered website files to preview branch
         id: commit
@@ -122,9 +125,6 @@ jobs:
           git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
           git push --force || echo "No changes to commit"
         shell: bash
-
-      - name: Website preview for download
-        run: zip website-preview.zip docs/* -r
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v2
@@ -145,6 +145,7 @@ jobs:
         run: |
           course_name=$(head -n 1 _website.yml | cut -d'"' -f 2| tr " " "-")
           website_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/index.html")
+          docs_link=$echo "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/website-preview.zip"
           echo ::set-output name=website_link::$website_link
           echo ::set-output name=time::$(date +'%Y-%m-%d')
           echo ::set-output name=commit_id::$GITHUB_SHA
@@ -157,7 +158,8 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Re-rendered previews from the latest commit: See [preview of website here](${{ steps.build-components.outputs.website_link }})
+            Quick preview for the latest commit: See [preview of website here](${{ steps.build-components.outputs.website_link }})
+            Comprehensive [downloadable preview files](${{ steps.build-components.outputs.docs_link}})
 
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -145,10 +145,11 @@ jobs:
         run: |
           course_name=$(head -n 1 _website.yml | cut -d'"' -f 2| tr " " "-")
           website_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/index.html")
-          docs_link=$(echo "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/website-preview.zip")
-          echo ::set-output name=website_link::$website_link
-          echo ::set-output name=time::$(date +'%Y-%m-%d')
-          echo ::set-output name=commit_id::$GITHUB_SHA
+          docs_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/website-preview.zip")
+          echo "docs_link=$docs_link" >> $GITHUB_OUTPUT
+          echo "website_link=$website_link" >> $GITHUB_OUTPUT
+          echo "time=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "commit_id=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo ${{steps.commit.outputs.changes}}
 
       - name: Create or update comment
@@ -159,7 +160,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Quick preview for the latest commit: See [preview of website here](${{ steps.build-components.outputs.website_link }})
-            Comprehensive [downloadable preview files](${{ steps.build-components.outputs.docs_link}})
+            Comprehensive [downloadable preview files](${{ steps.build-components.outputs.docs_link }})
 
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
@@ -175,3 +176,5 @@ jobs:
 
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
+
+

--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -72,10 +72,9 @@ jobs:
 # Commit the rendered site files - html files and site_libs files
       - name: Commit rendered site files
         run: |
-          git config --system --add safe.directory $GITHUB_WORKSPACE
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add --force docs/*
           git commit -m 'Render site' || echo "No changes to commit"
           git push origin main || echo "No changes to push"
-

--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -78,3 +78,13 @@ jobs:
           git add --force docs/*
           git commit -m 'Render site' || echo "No changes to commit"
           git push origin main || echo "No changes to push"
+
+      - name: Website preview for download
+        run: zip website-preview.zip docs/* -r
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v2
+        with:
+          name: website-preview
+          path: website-preview.zip
+          

--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -79,12 +79,3 @@ jobs:
           git commit -m 'Render site' || echo "No changes to commit"
           git push origin main || echo "No changes to push"
 
-      - name: Website preview for download
-        run: zip website-preview.zip docs/* -r
-
-      - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
-        with:
-          name: website-preview
-          path: website-preview.zip
-          

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata


### PR DESCRIPTION
## Summary 

Was trying to think of a way that a more comprehensive preview could be shown. Because at times I want to check for a change that https://htmlpreview.github.io can't handle -- dropdowns and font-awesome icons for example don't get shown. 

In this set up a rendered version of the website gets rendered as usually but a copy of it gets zipped up and archived so people could download it. 