### PR TITLE
Adding Issue and Pull Request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-website-add-to-sync.md
+++ b/.github/ISSUE_TEMPLATE/new-website-add-to-sync.md
@@ -1,0 +1,14 @@
+---
+name: Add your new website to syncs/OTTR updates
+about: Provide information about your new website (which uses the OTTR Website template) so that we can enroll it in OTTR updates
+title: ''
+labels: ''
+assignees: cansavvy
+
+---
+
+## What is the name of your new repository?
+<!-- The name of the repo. Ex the name of this repo is OTTR_Template_Website -->
+
+## What username or organization is your new repository associated with?
+<!-- The name of the username or organization where the new repository is located . Ex this repository is part of the jhudsl organization. A personal repository would be associated with a username instead of the organization. -->

--- a/.github/ISSUE_TEMPLATE/update-website-info-for-sync.md
+++ b/.github/ISSUE_TEMPLATE/update-website-info-for-sync.md
@@ -1,0 +1,26 @@
+---
+name: Update your website's info for syncs/OTTR updates
+about: Provide information about your moved/renamed website (which uses the OTTR Website template) so that it can continue to be enrolled in OTTR updates
+title: ''
+labels: ''
+assignees: cansavvy
+
+---
+
+<!-- Remove headings if they are not applicable to the changes/updates you made for your repo-->
+
+## If the name of your repository was changed ...
+
+### What was the old name?
+<!-- The old/original name of the repo. Ex the name of this repo is OTTR_Template_Website -->
+
+### What is the new name?
+<!-- The new/modified name of the repo. Ex the name of this repo is OTTR_Template_Website -->
+
+## If the repository was moved ...
+
+### What was the original username or organization your repository was associated with?
+<!-- The old/original name of the username or organization where the new repository was located . Ex this repository is part of the jhudsl organization. A personal repository would be associated with a username instead of the organization. -->
+
+### What is the new username or organization your repository was associated with?
+<!-- The new/modified name of the username or organization where the new repository is located . Ex this repository is part of the jhudsl organization. A personal repository would be associated with a username instead of the organization. -->

--- a/.github/ISSUE_TEMPLATE/website-content-add.md
+++ b/.github/ISSUE_TEMPLATE/website-content-add.md
@@ -1,0 +1,15 @@
+---
+name: New content idea
+about: Suggest an idea for the website
+title: ''
+labels: ''
+assignees:
+
+---
+
+## Describe the your scope of your content idea
+<!-- What will this cover and how does it relate to the current website material? -->
+
+
+## Additional context or resources
+<!-- Add any other context or related resources for the content idea? -->

--- a/.github/ISSUE_TEMPLATE/website-problem-report.md
+++ b/.github/ISSUE_TEMPLATE/website-problem-report.md
@@ -1,0 +1,28 @@
+---
+name: Website Problem Report
+about: Create a report to help improve a website
+title: [Problem]
+labels: bug
+assignees:
+
+---
+
+## Describe what is not working with the website
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to Reproduce
+<!-- Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/website-template-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/website-template-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Website Template Feature Request
+about: Suggest an idea for the website templates
+title: ''
+labels: ''
+assignees: cansavvy
+
+---
+
+## Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+## Describe alternatives you've considered
+<!--  A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Additional context
+<!-- Add any other context or screenshots about the feature request here.  -->

--- a/.github/ISSUE_TEMPLATE/website-template-problem-report.md
+++ b/.github/ISSUE_TEMPLATE/website-template-problem-report.md
@@ -1,0 +1,32 @@
+---
+name: Website Template Problem Report
+about: Create a report to help improve the template and its documentation
+title: Problem
+labels: bug
+assignees: cansavvy
+
+---
+
+## Describe what is not working with the template or is unclear in the documentation
+<!-- A clear and concise description of what the bug is. -->
+
+## Please link to the specific website repository you are working on
+
+## To Reproduce
+<!-- Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error -->
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Github actions links
+<!-- If applicable please link to the Github actions that has failed. -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/PULL_REQUEST_TEMPLATE/add_to_sync_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_to_sync_template.md
@@ -1,0 +1,9 @@
+---
+name: Add new repository to sync
+about: Enroll your repository for OTTR updates
+title: OTTR Updates Enrollment
+labels: ''
+assignees: cansavvy
+---
+
+Added __ repository to sync.yml in order to enroll in OTTR updates.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_general.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_general.md
@@ -1,0 +1,47 @@
+---
+name: New Content or Feature
+about: New Content or Feature Update
+title: General Update
+labels: ''
+assignees:
+---
+
+
+<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->
+
+### Purpose/implementation Section
+
+#### What changes are being implemented in this Pull Request?
+
+
+
+#### What was your approach?
+
+
+
+#### What GitHub issue does your pull request address?
+
+
+
+### Tell potential reviewers what kind of feedback you are soliciting.
+
+
+
+### New Content Checklist
+
+- [ ] New content/page is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/OTTR_Template_Website/blob/main/editing.Rmd).
+
+- [ ] Website successfully re-renders and any new content files have been added to the `_site.yml` file.
+
+- [ ] [Spell check runs successfully](https://www.ottrproject.org/customize-robots.html#Spell_checking)).
+
+- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://www.ottrproject.org/customize-docker.html).
+
+- [ ] Images are in the [correct format for rendering](https://www.ottrproject.org/writing_content_courses.html#set-up-images).
+
+- [ ] Every new image has [alt text and is in a Google Slide](https://www.ottrproject.org/writing_content_courses.html#Accessibility).
+
+- [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.
+
+- [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
+You can check this using [Color Oracle](https://colororacle.org/).

--- a/.github/workflows/file-automatic-issues.yml
+++ b/.github/workflows/file-automatic-issues.yml
@@ -17,7 +17,62 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
-      
+
+      - name: Login as github actions bot
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      # Delete Template-specific files that aren't needed for new websites
+      # Cleanup Template-specific bits
+      - name: Cleanup
+        run: |
+        rm -rf \
+          .github/workflows/file-automatic-issues.yml \
+          .github/ISSUE_TEMPLATE/new-website-add-to-sync.md \
+          .github/ISSUE_TEMPLATE/update-website-info-for-sync.md \
+          .github/ISSUE_TEMPLATE/website-template-feature-request.md \
+          .github/ISSUE_TEMPLATE/website-template-problem-report.md \
+          .github/PULL_REQUEST_TEMPLATE/add_to_sync_template.md \
+          .github/sync.yml \
+          .github/workflows/send-updates.yml \
+          .github/workflows/test-send-updates.yml \
+          docs/*.html
+
+      # Commit deleted files
+      - name: Commit deleted files
+        id: commit_it
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git commit -m "Template cleanup"
+          pushed_it=true
+          git push || pushed_it=false
+          echo "pushed_it=$pushed_it" >> $GITHUB_OUTPUT
+
+        # If main is already protected, then file a PR
+      - name: Create a PR with deleted files
+        if: steps.commit_it.outputs.pushed_it == 'false'
+        uses: peter-evans/create-pull-request@v3
+        id: pr
+        with:
+          commit-message: Delete unnecessary files
+          signoff: false
+          branch: auto_copy_rendered_files
+          delete-branch: true
+          title: 'Automatic course set up'
+          body: |
+            ### Description:
+             This PR was initiated by the github actions. It helps set up this repository to be ready to create your website.
+             It deletes some remnant files you don't need for your website but were used when this was a template.
+          labels: |
+            automated
+          reviewers: $GITHUB_ACTOR
+          token: ${{secrets.GH_PAT}}
+
         # Issue for what repository settings need to be set
       - name: New Course - Set Repository Settings
         uses: peter-evans/create-issue-from-file@v4


### PR DESCRIPTION
Adding Issue and Pull Request templates mirroring the main OTTR template.

Specifically was doing this because we added issue and pr templates for adding courses to OTTR syncs and we wanted to do this for websites too.

Used `wget` to get the raw `.md` files for each issue and PR template and edited them to reflect websites instead of courses. 

Still need to add a new website cleanup workflow because several of the templates assign @cansavvy to handle the issue or PR and we don't want that happening in other people's websites. @cansavvy do you want me to try to do this in a stacked PR and have you review it? 